### PR TITLE
Updated CSV files of Community suggestions

### DIFF
--- a/bugzilla.py
+++ b/bugzilla.py
@@ -252,7 +252,7 @@ def phabricator_api(method, data):
 			break
 
 		offset += 100
-		time.sleep(1)
+		time.sleep(2)
 
 	return results
 
@@ -719,7 +719,7 @@ Also see: https://codetribute.mozilla.org/projects/thunderbird
 			if data:
 				phab_users[user] = data[0]
 				changed = True
-			time.sleep(1)
+			time.sleep(2)
 
 		bmo_user = bmo_user_ids[phab_users[user]["id"]]
 		if bmo_user["name"] not in phab_users:
@@ -788,7 +788,18 @@ Also see: https://codetribute.mozilla.org/projects/thunderbird
 
 	with open(os.path.join(adir, "BMO_open_bug_votes.csv"), "w", newline="", encoding="utf-8") as csvfile:
 		writer = csv.writer(csvfile)
-		writer.writerow(("Votes", "Total Votes", "Reactions", "Type", "Product", "Component", "Summary", "Description", "URL"))
+		writer.writerow((
+			"Votes",
+			"Total Votes",
+			"Reactions",
+			"Date (UTC)",
+			"Type",
+			"Product",
+			"Component",
+			"Summary",
+			"Description",
+			"URL",
+		))
 
 		rows = []
 		for i, item in enumerate(sorted(aopen, key=operator.itemgetter("votes"), reverse=True), 1):
@@ -799,6 +810,7 @@ Also see: https://codetribute.mozilla.org/projects/thunderbird
 				f"{item['votes']}{''.join(f' + {sum(vote)}' for vote in votes if any(vote))}",
 				item["votes"] + sum(map(sum, votes)),
 				sum(item["comments"][0]["reactions"].values()) if item["comments"] else 0,
+				item["creation_time"],
 				# item['id'],
 				item["type"],
 				item["product"],

--- a/github.py
+++ b/github.py
@@ -850,7 +850,7 @@ def main():
 
 	with open(os.path.join(adir, "GitHub_open_reactions.csv"), "w", newline="", encoding="utf-8") as csvfile:
 		writer = csv.writer(csvfile)
-		writer.writerow(("Total Reactions", "+1 Reactions", "Repository", "Type", "Labels", "Title", "Body", "URL"))
+		writer.writerow(("Total Reactions", "+1 Reactions", "Date (UTC)", "Repository", "Type", "Labels", "Title", "Body", "URL"))
 
 		rows = []
 		for i, item in enumerate(
@@ -865,6 +865,7 @@ def main():
 			writer.writerow((
 				item["reactions"]["total_count"],
 				item["reactions"]["+1"],
+				item["created_at"],
 				url.path.split("/")[-1],
 				item["type"]["name"] if item["type"] else "",
 				", ".join(label["name"] for label in item["labels"]),


### PR DESCRIPTION
* Updated the Mozilla Connect script to track duplicate ideas
    * Added table of the top ideas by total duplicates (similar to the existing Bugzilla table)
* Updated the Mozilla Connect, Bugzilla and GitHub CSV files of Community suggestions
    * Added date column
    * Added total kudos column for Mozilla Connect (counting the kudos for duplicate ideas)
    * Updated to preserve link and image URLs for Mozilla Connect idea bodies when striping the HTML tags

Example CSV files with the updated output format can be [found here](https://docs.google.com/spreadsheets/d/1znYjnhnMACVMTZjhW6V7BjR6R2Bq3lWJwRDoPz0_2Mk/edit?usp=sharing).